### PR TITLE
Mark peer deps as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,19 @@
     "@tscircuit/core": "*",
     "@tscircuit/math-utils": "*"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "@tscircuit/core": {
+      "optional": true
+    },
+    "@tscircuit/math-utils": {
+      "optional": true
+    }
+  },
   "dependencies": {}
 }


### PR DESCRIPTION
## Summary
- add peerDependenciesMeta entries so all peer dependencies are marked optional

## Testing
- bunx tsc --noEmit
- bun run format (fails: Script not found "format")

------
https://chatgpt.com/codex/tasks/task_b_68e20bdec7e0832e86de86ee3baad9c4